### PR TITLE
Reset server states to avoid flaky tests

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/RestClientTestNoComponentIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/RestClientTestNoComponentIntegrationTests.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.MockServerRestTemplateCustomizer;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.client.MockRestServiceServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -45,7 +45,7 @@ class RestClientTestNoComponentIntegrationTests {
 	private RestTemplateBuilder restTemplateBuilder;
 
 	@Autowired
-	private MockRestServiceServer server;
+	private MockServerRestTemplateCustomizer customizer;
 
 	@Test
 	void exampleRestClientIsNotInjected() {
@@ -62,8 +62,9 @@ class RestClientTestNoComponentIntegrationTests {
 	@Test
 	void manuallyCreateBean() {
 		ExampleRestClient client = new ExampleRestClient(this.restTemplateBuilder);
-		this.server.expect(requestTo("/test")).andRespond(withSuccess("hello", MediaType.TEXT_HTML));
+		this.customizer.getServer(client.getRestTemplate()).expect(requestTo("/test")).andRespond(withSuccess("hello", MediaType.TEXT_HTML));
 		assertThat(client.test()).isEqualTo("hello");
+		this.customizer.getServer(client.getRestTemplate()).reset();
 	}
 
 }

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/RestClientTestTwoComponentsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/web/client/RestClientTestTwoComponentsIntegrationTests.java
@@ -60,6 +60,7 @@ class RestClientTestTwoComponentsIntegrationTests {
 		this.customizer.getServer(this.client1.getRestTemplate()).expect(requestTo("/test"))
 				.andRespond(withSuccess("hello", MediaType.TEXT_HTML));
 		assertThat(this.client1.test()).isEqualTo("hello");
+		this.customizer.getServer(this.client1.getRestTemplate()).reset();
 	}
 
 	@Test
@@ -67,6 +68,7 @@ class RestClientTestTwoComponentsIntegrationTests {
 		this.customizer.getServer(this.client2.getRestTemplate()).expect(requestTo("/test"))
 				.andRespond(withSuccess("there", MediaType.TEXT_HTML));
 		assertThat(this.client2.test()).isEqualTo("there");
+		this.customizer.getServer(this.client2.getRestTemplate()).reset();
 	}
 
 }


### PR DESCRIPTION
## What is the purpose of the change
- This PR is to fix 3 flaky tests:
```
Test1: org.springframework.boot.test.autoconfigure.web.client.RestClientTestNoComponentIntegrationTests.manuallyCreateBean
Test2: org.springframework.boot.test.autoconfigure.web.client.RestClientTestTwoComponentsIntegrationTests.client1RestCallViaCustomizer
Test3: org.springframework.boot.test.autoconfigure.web.client.RestClientTestTwoComponentsIntegrationTests.client2RestCallViaCustomizer
```


## Why the tests can be flaky
Test1:
- There is only one server that is already bound to the first RestTemplate. If multiple clients run, the server cannot be autoconfigured without `MockServerRestTemplateCustomizer`. We should reset the internal state by removing all expectations and recorded requests at the end of each test, to avoid pollution to other tests.

Test2 and Test3:
- The internal states were not reset after the tests run which can lead to polluting other tests.

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.

## Brief changelog
Test1:
- Use MockRestServiceServer by auto-configuration and reset internal state of the server at the end of the test.

Test2 and Test3:
- Reset internal state of the server at the end of the test

## Verifying this change
- Rerun the tests for more than one time in the same JVM, we get the following failures:

Test1:
```
java.lang.IllegalStateException: Unable to use auto-configured MockRestServiceServer since MockServerRestTemplateCustomizer has been bound to more than one RestTemplate
```
Test2 and Test3:
```
java.lang.IllegalStateException: Unable to return a single MockRestServiceServer since MockServerRestTemplateCustomizer has been bound to more than one RestTemplate
```
- With the proposed fix, the tests do not pollute the shared state (and pass when multiple tests that use this state are run in the same JVM).

